### PR TITLE
Add GitHub Actions CI quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  quality-gate:
+    name: Build, Vet & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download and verify dependencies
+        run: |
+          go mod download
+          go mod verify
+
+      - name: Check gofmt formatting
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Test with race detector
+        run: go test -race ./...
+
+      - name: Test with coverage
+        run: go test -cover ./...


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`: a single job running gofmt check, `go vet`, `go test`, `go test -race`, and `go test -cover`.
- Go version is read via `go-version-file: go.mod` (single source of truth, no duplication).
- Module cache is handled by `actions/setup-go`'s built-in `cache: true`.
- staticcheck was checked for and isn't used anywhere in the project, so it was intentionally left out.

## Test plan
- [x] Validated every pipeline command locally: `go mod download`/`verify`, `gofmt -l .`, `go vet ./...`, `go test ./...`, `go test -race ./...`, `go test -cover ./...` — all pass.
- [x] Validated the workflow YAML parses correctly.
- [ ] Confirm the Actions run passes once this PR triggers CI on GitHub.

Claude-Session: https://claude.ai/code/session_018NDHheV3J6nHsjbspxVebd