### PR TITLE
Implement core model types and the ScopeGuard security boundary

### DIFF
--- a/internal/adapters/httpclient/httpclient.go
+++ b/internal/adapters/httpclient/httpclient.go
@@ -1,1 +1,45 @@
+// Package httpclient is the real ports.HTTPClient adapter: a thin wrapper
+// around net/http.Client that enforces the ScopeGuard on every request
+// before it is sent.
 package httpclient
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/JonasBorgesLM/security-scanner/internal/core/scope"
+	"github.com/JonasBorgesLM/security-scanner/internal/ports"
+)
+
+var _ ports.HTTPClient = (*Client)(nil)
+
+// Client is the production ports.HTTPClient. Its only way to send a
+// request is Do, and Do always checks the ScopeGuard first — there is no
+// other path to the network through this type, so it is structurally
+// impossible to bypass scope enforcement while using it.
+type Client struct {
+	guard      *scope.ScopeGuard
+	httpClient *http.Client
+}
+
+// New builds a Client. guard must not be nil — it is the whole point of
+// this adapter. If httpClient is nil, http.DefaultClient is used.
+func New(guard *scope.ScopeGuard, httpClient *http.Client) *Client {
+	if guard == nil {
+		panic("httpclient: guard must not be nil")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{guard: guard, httpClient: httpClient}
+}
+
+// Do enforces the ScopeGuard against req's host before delegating to the
+// underlying net/http.Client. A request to a host outside the allowlist
+// never reaches the network: Do returns before dialing.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if err := c.guard.Check(req.URL.Host); err != nil {
+		return nil, fmt.Errorf("httpclient: request blocked: %w", err)
+	}
+	return c.httpClient.Do(req)
+}

--- a/internal/adapters/httpclient/httpclient_test.go
+++ b/internal/adapters/httpclient/httpclient_test.go
@@ -1,0 +1,87 @@
+package httpclient
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/JonasBorgesLM/security-scanner/internal/core/scope"
+)
+
+func newCountingServer(t *testing.T) (srv *httptest.Server, hits *int32) {
+	t.Helper()
+	hits = new(int32)
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, hits
+}
+
+// (a) A host in the allowlist passes through untouched.
+func TestClient_Do_AllowedHostReachesServer(t *testing.T) {
+	srv, hits := newCountingServer(t)
+
+	guard := scope.NewScopeGuard([]string{srv.Listener.Addr().String()})
+	client := New(guard, nil)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v, want nil for an allowed host", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Errorf("server received %d requests, want 1", got)
+	}
+}
+
+// (b) A host outside the allowlist is blocked, and — crucially — the
+// request never reaches the network at all.
+func TestClient_Do_BlockedHostNeverReachesServer(t *testing.T) {
+	srv, hits := newCountingServer(t)
+
+	// Deliberately does not include srv's host: everything is out of scope.
+	guard := scope.NewScopeGuard([]string{"only-this-host-is-allowed.invalid:9999"})
+	client := New(guard, nil)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+		t.Errorf("Do() response = %v, want nil when blocked", resp)
+	}
+	if err == nil {
+		t.Fatal("Do() error = nil, want an error for an out-of-scope host")
+	}
+	if !errors.Is(err, scope.ErrOutOfScope) {
+		t.Errorf("Do() error = %v, want errors.Is(err, scope.ErrOutOfScope)", err)
+	}
+	if got := atomic.LoadInt32(hits); got != 0 {
+		t.Errorf("server received %d requests, want 0 — an out-of-scope request must never touch the network", got)
+	}
+}
+
+func TestNew_PanicsOnNilGuard(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("New(nil, ...) did not panic; a ScopeGuard is mandatory")
+		}
+	}()
+	New(nil, nil)
+}

--- a/internal/core/model/check.go
+++ b/internal/core/model/check.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"context"
+
+	"github.com/JonasBorgesLM/security-scanner/internal/ports"
+)
+
+// CheckMetadata describes a check for registry lookup and engine
+// scheduling — never serialized, so it carries no JSON tags.
+type CheckMetadata struct {
+	Name          string
+	OWASPCategory string
+	Severity      string
+	Kind          string // "passive" | "active"
+	RequiresAuth  bool
+	AppliesTo     func(Endpoint) bool
+}
+
+// Check is implemented by every vulnerability check, self-registered into
+// the checks registry via init().
+type Check interface {
+	Metadata() CheckMetadata
+	Run(ctx context.Context, ep Endpoint, c ports.HTTPClient) ([]Finding, error)
+}

--- a/internal/core/model/endpoint.go
+++ b/internal/core/model/endpoint.go
@@ -1,0 +1,22 @@
+package model
+
+// Parameter describes a single input to an Endpoint, as discovered from the
+// OpenAPI spec — the injection point checks target with payloads.
+type Parameter struct {
+	Name     string `json:"name"`
+	In       string `json:"in"` // "query" | "path" | "header" | "body"
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}
+
+// Endpoint is a single route imported from the OpenAPI spec.
+type Endpoint struct {
+	Method         string      `json:"method"`
+	Path           string      `json:"path"`
+	Parameters     []Parameter `json:"parameters,omitempty"`
+	RequiresAuth   bool        `json:"requires_auth"`
+	SecurityScheme string      `json:"security_scheme,omitempty"`
+	// Destructive is true for DELETE/PUT/PATCH. Such endpoints are skipped
+	// by the engine unless the config opts in explicitly.
+	Destructive bool `json:"destructive"`
+}

--- a/internal/core/model/finding.go
+++ b/internal/core/model/finding.go
@@ -1,0 +1,43 @@
+package model
+
+import "time"
+
+// CapturedRequest is the complete request that produced a Finding, so the
+// attack stage can reproduce it exactly.
+type CapturedRequest struct {
+	Method        string            `json:"method"`
+	URL           string            `json:"url"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	Body          string            `json:"body,omitempty"`
+	InjectedParam string            `json:"injected_param,omitempty"`
+	Payload       string            `json:"payload,omitempty"`
+}
+
+// Evidence is what a check observed, including the baseline "clean"
+// response used to rule out false positives from dynamic content.
+type Evidence struct {
+	BaselineResponse string        `json:"baseline_response,omitempty"`
+	ResponseSnippet  string        `json:"response_snippet,omitempty"`
+	ResponseTime     time.Duration `json:"response_time"`
+	StatusCode       int           `json:"status_code"`
+}
+
+// Finding is a single suspected (scan) or confirmed (attack) vulnerability.
+type Finding struct {
+	ID            string          `json:"id"`
+	CheckName     string          `json:"check_name"`
+	Endpoint      Endpoint        `json:"endpoint"`
+	Severity      string          `json:"severity"`
+	OWASPCategory string          `json:"owasp_category"`
+	Request       CapturedRequest `json:"request"`
+	Evidence      Evidence        `json:"evidence"`
+	Confirmed     bool            `json:"confirmed"`
+}
+
+// FindingsFile is the on-disk, versioned JSON contract written by `scan`
+// (as findings.json) and `attack` (as confirmed.json), and read back by
+// the next stage.
+type FindingsFile struct {
+	SchemaVersion int       `json:"schema_version"`
+	Findings      []Finding `json:"findings"`
+}

--- a/internal/core/model/finding_test.go
+++ b/internal/core/model/finding_test.go
@@ -1,0 +1,108 @@
+package model
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestFinding_JSONRoundTrip(t *testing.T) {
+	original := Finding{
+		ID:        "finding-001",
+		CheckName: "sqli-boolean",
+		Endpoint: Endpoint{
+			Method: "GET",
+			Path:   "/users/{id}",
+			Parameters: []Parameter{
+				{Name: "id", In: "path", Type: "integer", Required: true},
+			},
+			RequiresAuth:   true,
+			SecurityScheme: "bearer",
+			Destructive:    false,
+		},
+		Severity:      "high",
+		OWASPCategory: "A03:2021-Injection",
+		Request: CapturedRequest{
+			Method: "GET",
+			URL:    "http://localhost:8080/users/1' OR '1'='1",
+			Headers: map[string]string{
+				"Authorization": "Bearer token",
+			},
+			Body:          "",
+			InjectedParam: "id",
+			Payload:       "' OR '1'='1",
+		},
+		Evidence: Evidence{
+			BaselineResponse: "{\"user\":null}",
+			ResponseSnippet:  "{\"user\":{\"id\":1,\"admin\":true}}",
+			ResponseTime:     250 * time.Millisecond,
+			StatusCode:       200,
+		},
+		Confirmed: true,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var decoded Finding
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(original, decoded) {
+		t.Errorf("round-trip mismatch:\noriginal = %+v\ndecoded  = %+v", original, decoded)
+	}
+}
+
+func TestFinding_JSONRoundTrip_ZeroValue(t *testing.T) {
+	original := Finding{}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var decoded Finding
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(original, decoded) {
+		t.Errorf("round-trip mismatch:\noriginal = %+v\ndecoded  = %+v", original, decoded)
+	}
+}
+
+func TestFindingsFile_JSONRoundTrip(t *testing.T) {
+	original := FindingsFile{
+		SchemaVersion: SchemaVersion,
+		Findings: []Finding{
+			{ID: "finding-001", CheckName: "missing-headers", Severity: "low"},
+			{ID: "finding-002", CheckName: "xss-reflected", Severity: "high", Confirmed: true},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var decoded FindingsFile
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(original, decoded) {
+		t.Errorf("round-trip mismatch:\noriginal = %+v\ndecoded  = %+v", original, decoded)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal() into map error = %v", err)
+	}
+	if _, ok := raw["schema_version"]; !ok {
+		t.Error("serialized FindingsFile is missing the schema_version field")
+	}
+}

--- a/internal/core/model/model.go
+++ b/internal/core/model/model.go
@@ -1,1 +1,8 @@
+// Package model holds the data types shared across the scan/attack/report
+// pipeline: endpoints discovered from the OpenAPI spec, check metadata, and
+// the findings each stage reads and writes as JSON.
 package model
+
+// SchemaVersion is the current version of the findings/confirmed JSON file
+// format written by the scan and attack stages.
+const SchemaVersion = 1

--- a/internal/core/scope/scope.go
+++ b/internal/core/scope/scope.go
@@ -1,1 +1,41 @@
+// Package scope implements the ScopeGuard — the central security boundary
+// of the scanner. Every outbound request must be checked against the host
+// allowlist before it is sent; this is what keeps the tool from ever
+// touching anything but the operator's own lab target.
 package scope
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrOutOfScope is returned when a host is not in the allowlist.
+var ErrOutOfScope = errors.New("scope: host not in allowlist")
+
+// ScopeGuard holds the allowlist of hosts the scanner is permitted to
+// contact. It is the single point of enforcement — no request may bypass
+// it, by design rather than by convention.
+type ScopeGuard struct {
+	allowed map[string]struct{}
+}
+
+// NewScopeGuard builds a ScopeGuard from a list of allowed hosts. Hosts
+// must match exactly what appears in a request URL's Host field, including
+// the port when the target uses a non-default one (e.g. "localhost:8080"),
+// matching scope.allowed_hosts in config.yaml.
+func NewScopeGuard(allowedHosts []string) *ScopeGuard {
+	allowed := make(map[string]struct{}, len(allowedHosts))
+	for _, h := range allowedHosts {
+		allowed[h] = struct{}{}
+	}
+	return &ScopeGuard{allowed: allowed}
+}
+
+// Check returns ErrOutOfScope if host is not in the allowlist, nil
+// otherwise.
+func (g *ScopeGuard) Check(host string) error {
+	if _, ok := g.allowed[host]; !ok {
+		return fmt.Errorf("%w: %q", ErrOutOfScope, host)
+	}
+	return nil
+}

--- a/internal/core/scope/scope_test.go
+++ b/internal/core/scope/scope_test.go
@@ -1,0 +1,37 @@
+package scope
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestScopeGuard_Check_AllowedHost(t *testing.T) {
+	g := NewScopeGuard([]string{"localhost:8080", "127.0.0.1:8080"})
+
+	if err := g.Check("localhost:8080"); err != nil {
+		t.Errorf("Check(%q) error = %v, want nil", "localhost:8080", err)
+	}
+	if err := g.Check("127.0.0.1:8080"); err != nil {
+		t.Errorf("Check(%q) error = %v, want nil", "127.0.0.1:8080", err)
+	}
+}
+
+func TestScopeGuard_Check_BlockedHost(t *testing.T) {
+	g := NewScopeGuard([]string{"localhost:8080"})
+
+	err := g.Check("evil.example.com")
+	if err == nil {
+		t.Fatal("Check() error = nil, want ErrOutOfScope for a host outside the allowlist")
+	}
+	if !errors.Is(err, ErrOutOfScope) {
+		t.Errorf("Check() error = %v, want errors.Is(err, ErrOutOfScope)", err)
+	}
+}
+
+func TestScopeGuard_Check_EmptyAllowlistBlocksEverything(t *testing.T) {
+	g := NewScopeGuard(nil)
+
+	if err := g.Check("localhost:8080"); !errors.Is(err, ErrOutOfScope) {
+		t.Errorf("Check() error = %v, want errors.Is(err, ErrOutOfScope) for an empty allowlist", err)
+	}
+}

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -1,1 +1,12 @@
+// Package ports declares the interfaces core and checks code depend on, so
+// they can be tested against fakes with no real network or disk I/O.
 package ports
+
+import "net/http"
+
+// HTTPClient is the sole boundary outbound requests may cross. The real
+// adapter (internal/adapters/httpclient) wires the ScopeGuard in as
+// middleware around Do; tests substitute a fake with canned responses.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}


### PR DESCRIPTION
## Summary
- Adds `internal/core/model`: `Endpoint`, `Parameter`, `CheckMetadata`, `Check` (interface), `Finding`, `CapturedRequest`, `Evidence`, plus `FindingsFile` — the `schema_version`-tagged wrapper that is the actual struct written to `findings.json`/`confirmed.json`.
- Adds `ports.HTTPClient`, the interface `Check.Run` and the real adapter depend on.
- Adds `internal/core/scope.ScopeGuard`: host allowlist, `ErrOutOfScope`, fail-closed on an empty allowlist.
- Adds `internal/adapters/httpclient.Client`: wraps `net/http.Client` and enforces `ScopeGuard.Check` on every `Do()` call before dialing — the only way to reach the network through this adapter, so scope enforcement can't be bypassed by construction.

## Test plan
- [x] `finding_test.go`: JSON round-trip for `Finding` (populated + zero value) and `FindingsFile` (asserts `schema_version` is present in the serialized output).
- [x] `scope_test.go`: allowed host passes, blocked host returns `ErrOutOfScope` (via `errors.Is`), empty allowlist blocks everything.
- [x] `httpclient_test.go`: `httptest.Server` with an atomic hit counter — in-scope request reaches the server (`hits == 1`); out-of-scope request is blocked *and never reaches the network* (`hits == 0`); `New(nil, ...)` panics since a guard is mandatory.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test ./... -race -cover` — `scope` and `httpclient` packages at 100% coverage.

Claude-Session: https://claude.ai/code/session_018NDHheV3J6nHsjbspxVebd