### PR TITLE
Allow the login body's username key to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ vez de escanear as rotas sem autenticação.
 |---|---|
 | `auth.login_endpoint` | Rota de login, resolvida contra o `base_url` |
 | `auth.credentials.username` / `password` | Credenciais do lab |
+| `auth.credentials.username_field` | Opcional, default `"username"` — chave JSON que carrega `username` no corpo do login (ex. `email`, para um alvo que loga por e-mail) |
 | `auth.token_path` | Caminho em notação de ponto até o token no JSON de resposta |
 
 ### Variáveis de ambiente

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -448,8 +448,9 @@ func authConfig(cfg *config.Config) auth.Config {
 		LoginEndpoint: cfg.Auth.LoginEndpoint,
 		Method:        cfg.Auth.Method,
 		Credentials: auth.Credentials{
-			Username: cfg.Auth.Credentials.Username,
-			Password: cfg.Auth.Credentials.Password,
+			Username:      cfg.Auth.Credentials.Username,
+			Password:      cfg.Auth.Credentials.Password,
+			UsernameField: cfg.Auth.Credentials.UsernameField,
 		},
 		TokenPath:   cfg.Auth.TokenPath,
 		TokenHeader: cfg.Auth.TokenHeader,

--- a/cmd/scanner/main_test.go
+++ b/cmd/scanner/main_test.go
@@ -16,8 +16,9 @@ func TestAuthConfig_MapsEveryField(t *testing.T) {
 			LoginEndpoint: "/signin",
 			Method:        "PUT",
 			Credentials: config.Credentials{
-				Username: "admin",
-				Password: "already-expanded",
+				Username:      "admin",
+				Password:      "already-expanded",
+				UsernameField: "email",
 			},
 			TokenPath:   "data.access_token",
 			TokenHeader: "X-Token",
@@ -38,6 +39,9 @@ func TestAuthConfig_MapsEveryField(t *testing.T) {
 	}
 	if got.Credentials.Password != "already-expanded" {
 		t.Errorf("Password = %q, want already-expanded", got.Credentials.Password)
+	}
+	if got.Credentials.UsernameField != "email" {
+		t.Errorf("UsernameField = %q, want email", got.Credentials.UsernameField)
 	}
 	if got.TokenPath != "data.access_token" {
 		t.Errorf("TokenPath = %q, want data.access_token", got.TokenPath)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -35,6 +35,10 @@ auth:
     # Never commit a real credential. ${VAR} is read from the environment
     # and the scanner fails with a clear error if the variable is unset.
     password: ${LAB_PASSWORD}
+    # Optional. JSON key `username` is sent under in the login body.
+    # Defaults to "username"; set to e.g. "email" for a target that logs
+    # in by email address.
+    # username_field: email
   # Dot-notation path to the token inside the JSON login response.
   # For {"data": {"access_token": "..."}} this is data.access_token
   token_path: data.access_token

--- a/doc/security-scanner-projeto.md
+++ b/doc/security-scanner-projeto.md
@@ -192,6 +192,7 @@ auth:
   credentials:
     username: admin
     password: ${LAB_PASSWORD}     # via env
+    username_field: email         # opcional, default "username" — chave JSON do login body
   token_path: data.access_token
   token_header: Authorization     # opcional, default Authorization
   token_prefix: "Bearer "

--- a/internal/adapters/config/config.go
+++ b/internal/adapters/config/config.go
@@ -50,6 +50,11 @@ type Scope struct {
 type Credentials struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
+	// UsernameField is the JSON key Username is sent under in the login
+	// request body. Optional; auth.New defaults it to "username" when
+	// empty. Set it to e.g. "email" for a target that logs in by email
+	// address instead of a literal username.
+	UsernameField string `yaml:"username_field"`
 }
 
 // Auth configures the automatic login + re-auth described in

--- a/internal/adapters/config/config_test.go
+++ b/internal/adapters/config/config_test.go
@@ -34,6 +34,9 @@ func TestLoad_ValidConfig(t *testing.T) {
 	if cfg.Auth.Credentials.Password != "s3cr3t-from-env" {
 		t.Errorf("Auth.Credentials.Password = %q, want the expanded env value, not the literal ${VAR}", cfg.Auth.Credentials.Password)
 	}
+	if cfg.Auth.Credentials.UsernameField != "email" {
+		t.Errorf("Auth.Credentials.UsernameField = %q, want email", cfg.Auth.Credentials.UsernameField)
+	}
 	if cfg.Auth.TokenPath != "data.access_token" {
 		t.Errorf("Auth.TokenPath = %q, want data.access_token", cfg.Auth.TokenPath)
 	}

--- a/internal/adapters/config/testdata/config.yaml
+++ b/internal/adapters/config/testdata/config.yaml
@@ -9,6 +9,7 @@ auth:
   credentials:
     username: admin
     password: ${SCANNER_TEST_LAB_PASSWORD}
+    username_field: email
   token_path: data.access_token
   token_header: Authorization
   token_prefix: "Bearer "

--- a/internal/core/auth/auth.go
+++ b/internal/core/auth/auth.go
@@ -38,6 +38,10 @@ const maxLoginBodyBytes = 1 << 20 // 1 MiB
 type Credentials struct {
 	Username string
 	Password string
+	// UsernameField is the JSON key Username is sent under in the login
+	// body, e.g. "email" for an API that logs in by email address rather
+	// than a literal username. Defaults to "username" when empty.
+	UsernameField string
 }
 
 // Config mirrors the auth: section of config.yaml (see
@@ -103,6 +107,9 @@ func New(baseURL string, cfg Config, inner ports.HTTPClient) (*Authenticator, er
 	}
 	if cfg.TokenHeader == "" {
 		cfg.TokenHeader = "Authorization"
+	}
+	if cfg.Credentials.UsernameField == "" {
+		cfg.Credentials.UsernameField = "username"
 	}
 
 	password, err := envexpand.Expand(cfg.Credentials.Password)
@@ -196,8 +203,8 @@ func (a *Authenticator) login(ctx context.Context) error {
 	}
 
 	body, err := json.Marshal(map[string]string{
-		"username": a.cfg.Credentials.Username,
-		"password": a.cfg.Credentials.Password,
+		a.cfg.Credentials.UsernameField: a.cfg.Credentials.Username,
+		"password":                      a.cfg.Credentials.Password,
 	})
 	if err != nil {
 		return fmt.Errorf("auth: encode login body: %w", err)

--- a/internal/core/auth/auth_test.go
+++ b/internal/core/auth/auth_test.go
@@ -449,6 +449,49 @@ func TestNew_AppliesDefaults(t *testing.T) {
 	if a.cfg.TokenHeader != "Authorization" {
 		t.Errorf("TokenHeader = %q, want Authorization", a.cfg.TokenHeader)
 	}
+	if a.cfg.Credentials.UsernameField != "username" {
+		t.Errorf("Credentials.UsernameField = %q, want %q", a.cfg.Credentials.UsernameField, "username")
+	}
+}
+
+// TestAuthenticator_SendsCredentialsUnderCustomUsernameField covers a
+// target that logs in by email rather than a literal username (e.g.
+// task-api's POST /auth/login, which expects {"email": ...}): the login
+// body must carry Credentials.Username under the configured
+// UsernameField key, not a hardcoded "username".
+func TestAuthenticator_SendsCredentialsUnderCustomUsernameField(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Fatalf("unmarshal login body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"token": "tok-1"})
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := testConfig()
+	cfg.Credentials.UsernameField = "email"
+	cfg.TokenPath = "token"
+	a, err := New(srv.URL, cfg, http.DefaultClient)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := a.Authenticate(t.Context()); err != nil {
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+
+	if _, ok := gotBody["username"]; ok {
+		t.Errorf("login body has key %q, want it absent when UsernameField overrides it", "username")
+	}
+	if got := gotBody["email"]; got != cfg.Credentials.Username {
+		t.Errorf("login body[%q] = %q, want %q", "email", got, cfg.Credentials.Username)
+	}
+	if got := gotBody["password"]; got != cfg.Credentials.Password {
+		t.Errorf("login body[%q] = %q, want %q", "password", got, cfg.Credentials.Password)
+	}
 }
 
 func TestExtractToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- Scanning `task-api` (a real target, not the synthetic `lab/`) surfaced that the `scan`/`attack` login flow always sent `{"username": ...}` — but task-api authenticates by email (`{"email": ...}`), so login failed and every protected route came back `skipped`.
- Adds `auth.credentials.username_field` to `config.yaml` (optional, defaults to `"username"` — fully backward compatible with existing configs). `internal/core/auth.New` applies the default the same way it already does for `Method`/`TokenHeader`; `internal/core/auth.login` marshals the credential under that key instead of a hardcoded `"username"`.
- Updated the shipped example (`configs/config.yaml`), the format-of-record doc (`doc/security-scanner-projeto.md` §6), and `README.md`'s config table.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./...` (all packages pass)
- [x] New coverage: `TestAuthenticator_SendsCredentialsUnderCustomUsernameField` (asserts the wire body uses the configured key, not `"username"`), `TestNew_AppliesDefaults` extended for the `"username"` default, `TestLoad_ValidConfig` extended for YAML parsing, `TestAuthConfig_MapsEveryField` extended for the config→auth mapping.
- [x] Manually verified end-to-end against a real `task-api` instance: `scan` now authenticates and produces findings for all 10 previously-`skipped` protected routes.